### PR TITLE
GameDTO wrong returntype

### DIFF
--- a/domain/src/main/java/net/boreeas/riotapi/com/riotgames/platform/game/Game.java
+++ b/domain/src/main/java/net/boreeas/riotapi/com/riotgames/platform/game/Game.java
@@ -44,8 +44,8 @@ public class Game {
     private Object statusOfParticipants;
     private long id;
     private PlayerParticipant ownerSummary;
-    private List<Participant> teamOne = new ArrayList<>();
-    private List<Participant> teamTwo = new ArrayList<>();
+    private List<PlayerParticipant> teamOne = new ArrayList<>();
+    private List<PlayerParticipant> teamTwo = new ArrayList<>();
     private List<BannedChampion> bannedChampions = new ArrayList<>();
     private String roomName;
     private String name;


### PR DESCRIPTION
Running the following code:

``` java
        for (final Participant p : rtmpClient.gameService
                .retrieveInProgressSpectatorGameInfo("zirckonium").getGame()
                .getTeamTwo()) {
            System.out.println(p);
        }
```

Gives me:

```
PlayerParticipant(timeAddedToQueue=1.408716621694E12, index=0, queueRating=0, accountId=41535110, botDifficulty=NONE, originalAccountNumber=41535110, summonerInternalName=yenzo007, minor=false, locale=null, lastSelectedSkinIndex=0, partnerId=, profileIconId=657, teamOwner=true, summonerId=39298641, badges=0, pickTurn=1, clientInSynch=true, summonerName=yenzo007, pickMode=0, originalPlatformId=EUW1, teamParticipantId=4.20831517E8, pointSummary=null)
PlayerParticipant(timeAddedToQueue=1.408716630196E12, index=0, queueRating=0, accountId=208637922, botDifficulty=NONE, originalAccountNumber=208637922, summonerInternalName=haaaagayy, minor=false, locale=null, lastSelectedSkinIndex=0, partnerId=, profileIconId=21, teamOwner=false, summonerId=53768386, badges=0, pickTurn=1, clientInSynch=true, summonerName=HAAAAgayy, pickMode=0, originalPlatformId=EUW1, teamParticipantId=null, pointSummary=null)
PlayerParticipant(timeAddedToQueue=1.408716621694E12, index=0, queueRating=0, accountId=31171102, botDifficulty=NONE, originalAccountNumber=31171102, summonerInternalName=yourworsestdream, minor=false, locale=null, lastSelectedSkinIndex=1, partnerId=, profileIconId=660, teamOwner=false, summonerId=27323103, badges=0, pickTurn=1, clientInSynch=true, summonerName=yourworsestdream, pickMode=0, originalPlatformId=EUW1, teamParticipantId=4.20831517E8, pointSummary=null)
PlayerParticipant(timeAddedToQueue=1.408716621694E12, index=0, queueRating=0, accountId=39269830, botDifficulty=NONE, originalAccountNumber=39269830, summonerInternalName=ecloit, minor=false, locale=null, lastSelectedSkinIndex=0, partnerId=, profileIconId=592, teamOwner=false, summonerId=36128631, badges=0, pickTurn=1, clientInSynch=true, summonerName=ecloit, pickMode=0, originalPlatformId=EUW1, teamParticipantId=4.20831517E8, pointSummary=null)
PlayerParticipant(timeAddedToQueue=1.408716621694E12, index=0, queueRating=0, accountId=33386542, botDifficulty=NONE, originalAccountNumber=33386542, summonerInternalName=zirckonium, minor=false, locale=null, lastSelectedSkinIndex=0, partnerId=, profileIconId=603, teamOwner=false, summonerId=29599938, badges=0, pickTurn=1, clientInSynch=true, summonerName=Zirckonium, pickMode=0, originalPlatformId=EUW1, teamParticipantId=4.20831517E8, pointSummary=null)
```

So I'm guessing that the return type of `teamOne` and `teamTwo` in GameDTO should be `List<PlayerParticipant>` instead of `List<Participant>`.
