### PR TITLE
Updated spectating urls

### DIFF
--- a/domain/src/main/java/net/boreeas/riotapi/Shard.java
+++ b/domain/src/main/java/net/boreeas/riotapi/Shard.java
@@ -76,7 +76,7 @@ public enum Shard {
             "chat.oc1." + Constants.BASE_PATH,
             "https://lq.oc1." + Constants.BASE_PATH,
             "prod.oc1." + Constants.BASE_PATH,
-            "http://192.64.169.29" + Constants.BASE_PATH),
+            "http://spectator.oc1." + Constants.BASE_PATH),
     TR("tr",
             String.format(Constants.API_PATH_TEMPLATE, "tr"),
             // Alt values if loading fails


### PR DESCRIPTION
The Korean quickfind proxy doesn't exist anymore and isn't needed anymore. Changed it to the official one :) And I updated the spectator urls to the working ones.
