### PR TITLE
Adding a property for champion name.

### DIFF
--- a/rest/src/main/java/net/boreeas/riotapi/rest/Champion.java
+++ b/rest/src/main/java/net/boreeas/riotapi/rest/Champion.java
@@ -32,6 +32,7 @@ public class Champion {
     private int id;
     private Image image;
     private ChampionInfo info;
+    private String name;
     private String key;
     private String lore;
     private String partype;


### PR DESCRIPTION
The Champion class in the REST API didn't have name, which is one of the properties in the JSON. Seemed like an important one to have as Key isn't always the same (keys dont have ' or spaces, and wukong has MonkeyKing as it's key).