### PR TITLE
make participant runes and masteries accessable

### DIFF
--- a/rest/src/main/java/net/boreeas/riotapi/rest/InProgressGameParticipant.java
+++ b/rest/src/main/java/net/boreeas/riotapi/rest/InProgressGameParticipant.java
@@ -37,12 +37,14 @@ public class InProgressGameParticipant {
     private String summonerName;
     private long teamId;
 
-    private class Mastery {
+    @Data
+    public class Mastery {
         private int masteryId;
         private int rank;
     }
 
-    private class Rune {
+    @Data
+    public class Rune {
         private int count;
         private long runeId;
     }


### PR DESCRIPTION
Runes and Masteries from InProgressGameParticipant are not useable because they are set to private classes without getters/setters.
